### PR TITLE
fix(deps): move @graphql-tools/delegate to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   },
   "author": "Matic Zavadlal <matic.zavadlal@gmail.com>",
   "dependencies": {
-    "@graphql-tools/schema": "^7.1.2"
+    "@graphql-tools/schema": "^7.1.2",
+    "@graphql-tools/delegate": "^7.0.8"
   },
   "devDependencies": {
-    "@graphql-tools/delegate": "^7.0.8",
     "@types/graphql": "^14.5.0",
     "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.167",


### PR DESCRIPTION
Hey, I just update the library `graphql-middleware` to the version `6.0.0`. Since then I can't build my project anymore. I noticed that the library `@graphql-tools/delegate` is not installed on my side, that's because it's not referenced as a dependency.

```
node_modules/graphql-middleware/dist/types.d.ts:2:31 - error TS2307: Cannot find module '@graphql-tools/delegate' or its corresponding type declarations.

2 import { StitchingInfo } from '@graphql-tools/delegate';
                                ~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command. 
```

### How to reproduce?
> I think i figure it out. Graphql-shield is still using an older version. If I use 4.0.0 of the middleware then it works.
> 
> Here is the reproduction repo if you want to try it out.
> https://github.com/cernicc/temp

Source: https://github.com/maticzav/graphql-middleware/issues/314#issuecomment-750849846