### PR TITLE
fix: specify './package.json' in 'exports'

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },
+    "./package.json": {
+      "require": "./package.json",
+      "import": "./package.json"
+    },
     "./*": {
       "require": "./dist/*.js",
       "import": "./dist/*.mjs"


### PR DESCRIPTION
Some javascript bundlers use `require.resolve` to identify the `package.json`. If the `package.json` can't be resolved, the dependency isn't included.

Specifically in my case, [generate-package-json-webpack-plugin](https://github.com/lostpebble/generate-package-json-webpack-plugin/blob/master/index.js#L101) was having trouble locating the `package.json` due to the export fields.

Test case, before:
```
$ npm i graphql

$ npm i graphql-middleware

$ node

> require.resolve("graphql/package.json", { paths: ["/Users/theochupp/Documents/graphql-middleware-test/apps/graphql/src"], })
'/Users/theochupp/Documents/graphql-middleware-test/node_modules/graphql/package.json'

> require.resolve("graphql-middleware/package.json", { paths: ["/Users/theochupp/Documents/graphql-middleware-test/apps/graphql/src"], })
Uncaught:
Error: Cannot find module '/Users/theochupp/Documents/graphql-middleware-test/node_modules/graphql-middleware/dist/package.json.js'
    at createEsmNotFoundErr (internal/modules/cjs/loader.js:842:15)
    at finalizeEsmResolution (internal/modules/cjs/loader.js:835:15)
    at resolveExports (internal/modules/cjs/loader.js:424:14)
    at Function.Module._findPath (internal/modules/cjs/loader.js:464:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:802:27)
    at Function.resolve (internal/modules/cjs/helpers.js:80:19) {
  code: 'MODULE_NOT_FOUND',
  path: '/Users/theochupp/Documents/graphql-middleware-test/node_modules/graphql-middleware/package.json'
}
```

Test case, after:
```
$ npm i graphql

$ npm i graphql-middleware

$ node

> require.resolve("graphql/package.json", { paths: ["/Users/theochupp/Documents/graphql-middleware-test/apps/graphql/src"], })
'/Users/theochupp/Documents/graphql-middleware-test/node_modules/graphql/package.json'

> require.resolve("graphql-middleware/package.json", { paths: ["/Users/theochupp/Documents/graphql-middleware-test/apps/graphql/src"], })
'/Users/theochupp/Documents/graphql-middleware-test/node_modules/graphql-middleware/package.json'
```

I'm not sure this is even worth adding a unit test for 😂