### PR TITLE
bump graphql.js to v16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,19 +23,19 @@
   },
   "author": "Matic Zavadlal <matic.zavadlal@gmail.com>",
   "dependencies": {
+    "@apollo/client": "^3.6.9",
     "@graphql-tools/delegate": "^8.8.0",
     "@graphql-tools/schema": "^8.5.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",
     "@types/lodash": "^4.14.182",
-    "apollo-link": "^1.2.14",
-    "apollo-server": "^2.25.4",
+    "apollo-server": "3.9.0",
     "axios": "^0.27.2",
     "bob-esbuild": "^1.3.0",
     "bob-esbuild-cli": "^1.0.1",
     "codecov": "^3.8.3",
-    "graphql": "^15.8.0",
+    "graphql": "^16.5.0",
     "husky": "^6.0.0",
     "iterall": "^1.3.0",
     "jest": "^26.6.3",
@@ -48,7 +48,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/src/applicator.ts
+++ b/src/applicator.ts
@@ -41,7 +41,7 @@ function wrapResolverInMiddleware<TSource, TContext, TArgs>(
 }
 
 function parseField(field: GraphQLField<any, any, any>) {
-  const { isDeprecated, ...restData } = field
+  const { deprecationReason, ...restData } = field
   const argsMap = field.args.reduce(
     (acc, cur) => ({
       ...acc,
@@ -198,7 +198,7 @@ function applyMiddlewareToSchema<TSource, TContext, TArgs>(
 export function generateResolverFromSchemaAndMiddleware<
   TSource,
   TContext,
-  TArgs
+  TArgs,
 >(
   schema: GraphQLSchema,
   options: IApplyOptions,

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,7 +1,6 @@
 import { makeExecutableSchema } from '@graphql-tools/schema'
-import { graphql, subscribe, parse } from 'graphql'
+import { graphql, subscribe, parse, ExecutionResult } from 'graphql'
 import { $$asyncIterator } from 'iterall'
-import { ExecutionResult } from 'apollo-link'
 
 import { applyMiddleware } from '../src'
 import {
@@ -161,7 +160,7 @@ describe('core:', () => {
         nested { nothing }
       }
     `
-    const res = await graphql(schemaWithMiddleware, query)
+    const res = await graphql({ schema: schemaWithMiddleware, source: query })
 
     /* Tests. */
 
@@ -195,7 +194,10 @@ describe('core:', () => {
         sub
       }
     `
-    const iterator = await subscribe(schemaWithMiddleware, parse(query))
+    const iterator = await subscribe({
+      schema: schemaWithMiddleware,
+      document: parse(query),
+    })
     const res = await (iterator as AsyncIterator<ExecutionResult>).next()
 
     /* Tests. */
@@ -224,7 +226,7 @@ describe('core:', () => {
         nested { nothing }
       }
     `
-    const res = await graphql(schemaWithMiddleware, query)
+    const res = await graphql({ schema: schemaWithMiddleware, source: query })
 
     /* Tests. */
 
@@ -254,7 +256,7 @@ describe('core:', () => {
         nested { nothing }
       }
     `
-    const res = await graphql(schemaWithMiddleware, query)
+    const res = await graphql({ schema: schemaWithMiddleware, source: query })
 
     /* Tests. */
 
@@ -279,7 +281,10 @@ describe('core:', () => {
         sub
       }
     `
-    const iterator = await subscribe(schemaWithMiddleware, parse(query))
+    const iterator = await subscribe({
+      schema: schemaWithMiddleware,
+      document: parse(query),
+    })
     const res = await (iterator as AsyncIterator<ExecutionResult>).next()
 
     expect(res).toEqual({
@@ -306,7 +311,7 @@ describe('core:', () => {
         nested { nothing }
       }
     `
-    const res = await graphql(schemaWithMiddleware, query)
+    const res = await graphql({ schema: schemaWithMiddleware, source: query })
 
     /* Tests. */
 
@@ -336,7 +341,7 @@ describe('core:', () => {
         nested { nothing }
       }
     `
-    const res = await graphql(schemaWithMiddleware, query)
+    const res = await graphql({ schema: schemaWithMiddleware, source: query })
 
     /* Tests. */
 
@@ -366,7 +371,7 @@ describe('core:', () => {
         nested { nothing }
       }
     `
-    const res = await graphql(schemaWithMiddleware, query)
+    const res = await graphql({ schema: schemaWithMiddleware, source: query })
 
     /* Tests. */
 
@@ -391,7 +396,10 @@ describe('core:', () => {
         sub
       }
     `
-    const iterator = await subscribe(schemaWithMiddleware, parse(query))
+    const iterator = await subscribe({
+      schema: schemaWithMiddleware,
+      document: parse(query),
+    })
     const res = await (iterator as AsyncIterator<ExecutionResult>).next()
 
     expect(res).toEqual({
@@ -415,7 +423,7 @@ describe('core:', () => {
         }
       }
     `
-    const res = await graphql(schemaWithMiddleware, query)
+    const res = await graphql({ schema: schemaWithMiddleware, source: query })
 
     expect(res).toEqual({
       data: {

--- a/tests/execution.test.ts
+++ b/tests/execution.test.ts
@@ -50,7 +50,7 @@ describe('execution:', () => {
         test
       }
     `
-    await graphql(schemaWithMiddleware, query, null, {})
+    await graphql({ schema: schemaWithMiddleware, source: query })
 
     /* Tests */
 
@@ -90,7 +90,7 @@ describe('execution:', () => {
       }
     `
 
-    const res = await graphql(schemaWithMiddleware, query)
+    const res = await graphql({ schema: schemaWithMiddleware, source: query })
 
     /* Tests. */
 
@@ -148,7 +148,7 @@ describe('execution:', () => {
       }
     `
 
-    const res = await graphql(schemaWithMiddleware, query)
+    const res = await graphql({ schema: schemaWithMiddleware, source: query })
 
     /* Tests. */
     expect(firstMiddleware).toHaveBeenCalledTimes(1)

--- a/tests/immutability.test.ts
+++ b/tests/immutability.test.ts
@@ -43,23 +43,23 @@ test('immutable', async () => {
     }
   `
 
-  const responseWithMiddleware = await graphql(
-    schemaWithMiddlewares,
-    query,
-    {},
-    { middlewareCalled: false },
-    {},
-  )
+  const responseWithMiddleware = await graphql({
+    schema: schemaWithMiddlewares,
+    source: query,
+    contextValue: { middlewareCalled: false },
+    variableValues: {},
+    rootValue: {},
+  })
   expect(responseWithMiddleware.errors).toBeUndefined()
   expect(responseWithMiddleware.data!.test).toEqual(true)
 
-  const responseWihoutMiddleware = await graphql(
-    schema,
-    query,
-    {},
-    { middlewareCalled: false },
-    {},
-  )
+  const responseWihoutMiddleware = await graphql({
+    schema: schema,
+    source: query,
+    contextValue: { middlewareCalled: false },
+    variableValues: {},
+    rootValue: {},
+  })
   expect(responseWihoutMiddleware.errors).toBeUndefined()
   expect(responseWihoutMiddleware.data!.test).toEqual(false)
 })


### PR DESCRIPTION
Updates:

Graphql.js 16.x
Apollo Server 3.x

Update tests to use new syntax from v16

Possible fix for: #500 